### PR TITLE
Embedding superset in iframe

### DIFF
--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -19,11 +19,7 @@ data:
         self.app = app
 
       def __call__(self, environ, start_response):
-        # if one of x_forwarded or preferred_url is https, prefer it.
-        forwarded_scheme = environ.get("HTTP_X_FORWARDED_PROTO", None)
-        preferred_scheme = app.config.get("PREFERRED_URL_SCHEME", None)
-        if "https" in [forwarded_scheme, preferred_scheme]:
-          environ["wsgi.url_scheme"] = "https"
+        environ["wsgi.url_scheme"] = "https"
         return self.app(environ, start_response)
 
     if os.environ["ALLOW_IFRAME"] == "True":

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -15,16 +15,16 @@ data:
       use environ/config to signal https
       since flask ignores preferred_url_scheme in url_for calls
       """
-        def __init__(self, app):
-          self.app = app
+      def __init__(self, app):
+        self.app = app
 
-        def __call__(self, environ, start_response):
-          # if one of x_forwarded or preferred_url is https, prefer it.
-          forwarded_scheme = environ.get("HTTP_X_FORWARDED_PROTO", None)
-          preferred_scheme = app.config.get("PREFERRED_URL_SCHEME", None)
-          if "https" in [forwarded_scheme, preferred_scheme]:
-            environ["wsgi.url_scheme"] = "https"
-          return self.app(environ, start_response)
+      def __call__(self, environ, start_response):
+        # if one of x_forwarded or preferred_url is https, prefer it.
+        forwarded_scheme = environ.get("HTTP_X_FORWARDED_PROTO", None)
+        preferred_scheme = app.config.get("PREFERRED_URL_SCHEME", None)
+        if "https" in [forwarded_scheme, preferred_scheme]:
+          environ["wsgi.url_scheme"] = "https"
+        return self.app(environ, start_response)
 
     if os.environ["ALLOW_IFRAME"] == "True":
       # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -20,6 +20,9 @@ data:
       WTF_CSRF_ENABLED = False
 
       HTTP_HEADERS = {'X-Frame-Options': 'ALLOWALL'}
+
+      # prevent redirect from https to http
+      SUPERSET_WEBSERVER_PROTOCOL = "https"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -8,6 +8,24 @@ data:
 
     SQLALCHEMY_DATABASE_URI = 'postgresql://superset:superset@db/superset'
 
+    # https://github.com/komoot/superset-reverse-nginx-example/blob/master/superset_config.py
+    class ReverseProxied(object):
+      """
+      Because we are reverse proxied from an aws load balancer
+      use environ/config to signal https
+      since flask ignores preferred_url_scheme in url_for calls
+      """
+        def __init__(self, app):
+          self.app = app
+
+        def __call__(self, environ, start_response):
+          # if one of x_forwarded or preferred_url is https, prefer it.
+          forwarded_scheme = environ.get("HTTP_X_FORWARDED_PROTO", None)
+          preferred_scheme = app.config.get("PREFERRED_URL_SCHEME", None)
+          if "https" in [forwarded_scheme, preferred_scheme]:
+            environ["wsgi.url_scheme"] = "https"
+          return self.app(environ, start_response)
+
     if os.environ["ALLOW_IFRAME"] == "True":
       # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
       SESSION_COOKIE_SAMESITE = None
@@ -22,7 +40,7 @@ data:
       HTTP_HEADERS = {'X-Frame-Options': 'ALLOWALL'}
 
       # prevent redirect from https to http
-      SUPERSET_WEBSERVER_PROTOCOL = "https"
+      ADDITIONAL_MIDDLEWARE = [ReverseProxied, ]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -5,6 +5,9 @@ metadata:
 data:
   superset_config.py: |
     SQLALCHEMY_DATABASE_URI = 'postgresql://superset:superset@db/superset'
+
+    # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
+    SESSION_COOKIE_SAMESITE = 'None'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -42,6 +45,8 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
+        - name: IFRAME_MODE
+          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config
@@ -61,6 +66,8 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
+        - name: IFRAME_MODE
+          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -8,6 +8,7 @@ data:
 
     # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
     SESSION_COOKIE_SAMESITE = 'None'
+    SESSION_COOKIE_HTTPONLY = False
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -4,17 +4,22 @@ metadata:
   name: superset-config
 data:
   superset_config.py: |
+    import os
+
     SQLALCHEMY_DATABASE_URI = 'postgresql://superset:superset@db/superset'
 
-    # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
-    SESSION_COOKIE_SAMESITE = None
-    SESSION_COOKIE_HTTPONLY = False
+    if os.environ["ALLOW_IFRAME"] == "True":
+      # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
+      SESSION_COOKIE_SAMESITE = None
+      SESSION_COOKIE_HTTPONLY = False
 
-    # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
-    ENABLE_PROXY_FIX = True
+      # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
+      ENABLE_PROXY_FIX = True
 
-    # CSRF
-    WTF_CSRF_ENABLED = False
+      # CSRF
+      WTF_CSRF_ENABLED = False
+
+      HTTP_HEADERS = {'X-Frame-Options': 'ALLOWALL'}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -52,6 +57,8 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
+        - name: ALLOW_IFRAME
+          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config
@@ -71,6 +78,8 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
+        - name: ALLOW_IFRAME
+          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -9,6 +9,9 @@ data:
     # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
     SESSION_COOKIE_SAMESITE = None
     SESSION_COOKIE_HTTPONLY = False
+
+    # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
+    ENABLE_PROXY_FIX = True
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,8 +49,6 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
-        - name: IFRAME_MODE
-          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config
@@ -67,8 +68,6 @@ spec:
         env:
         - name: SUPERSET_CONFIG_PATH
           value: /superset-config/superset_config.py
-        - name: IFRAME_MODE
-          value: "False"
         volumeMounts:
         - name: config-volume
           mountPath: /superset-config

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -24,7 +24,8 @@ data:
 
     if os.environ["ALLOW_IFRAME"] == "True":
       # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
-      SESSION_COOKIE_SAMESITE = None
+      SESSION_COOKIE_SAMESITE = 'None'
+      SESSION_COOKIE_SECURE = True
       SESSION_COOKIE_HTTPONLY = False
 
       # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -7,7 +7,7 @@ data:
     SQLALCHEMY_DATABASE_URI = 'postgresql://superset:superset@db/superset'
 
     # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
-    SESSION_COOKIE_SAMESITE = 'None'
+    SESSION_COOKIE_SAMESITE = None
     SESSION_COOKIE_HTTPONLY = False
 ---
 apiVersion: apps/v1

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -12,6 +12,9 @@ data:
 
     # Use all X-Forwarded headers when ENABLE_PROXY_FIX is True.
     ENABLE_PROXY_FIX = True
+
+    # CSRF
+    WTF_CSRF_ENABLED = False
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/.staroid/k8s/superset.yaml
+++ b/.staroid/k8s/superset.yaml
@@ -8,20 +8,6 @@ data:
 
     SQLALCHEMY_DATABASE_URI = 'postgresql://superset:superset@db/superset'
 
-    # https://github.com/komoot/superset-reverse-nginx-example/blob/master/superset_config.py
-    class ReverseProxied(object):
-      """
-      Because we are reverse proxied from an aws load balancer
-      use environ/config to signal https
-      since flask ignores preferred_url_scheme in url_for calls
-      """
-      def __init__(self, app):
-        self.app = app
-
-      def __call__(self, environ, start_response):
-        environ["wsgi.url_scheme"] = "https"
-        return self.app(environ, start_response)
-
     if os.environ["ALLOW_IFRAME"] == "True":
       # to allow iframe embedding. https://github.com/apache/incubator-superset/issues/8382
       SESSION_COOKIE_SAMESITE = 'None'
@@ -36,8 +22,22 @@ data:
 
       HTTP_HEADERS = {'X-Frame-Options': 'ALLOWALL'}
 
-      # prevent redirect from https to http
-      ADDITIONAL_MIDDLEWARE = [ReverseProxied, ]
+    # https://github.com/komoot/superset-reverse-nginx-example/blob/master/superset_config.py
+    class ReverseProxied(object):
+      """
+      Because we are reverse proxied from an aws load balancer
+      use environ/config to signal https
+      since flask ignores preferred_url_scheme in url_for calls
+      """
+      def __init__(self, app):
+        self.app = app
+
+      def __call__(self, environ, start_response):
+        environ["wsgi.url_scheme"] = "https"
+        return self.app(environ, start_response)
+
+    # prevent redirect from https to http
+    ADDITIONAL_MIDDLEWARE = [ReverseProxied, ]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/.staroid/staroid.yaml
+++ b/.staroid/staroid.yaml
@@ -5,4 +5,20 @@ build:
 ingress:
   - serviceName: superset
     port: 8088
-deploy: {}
+deploy:
+  paramGroups:
+  - name: Configuration
+    collapsed: true
+    params:
+    - name: Iframe mode
+      description: Set 'True' to embed superset in iframe from different domain. This option will disable CSRF.
+      type: STRING
+      defaultValue: "False"
+      options:
+        - name: "True"
+          value: "True"
+        - name: "False"
+          value: "False"
+      paths:
+      - Deployment:superset:spec.template.spec.initContainers[0].env[1].value # IFRAME_MODE
+      - Deployment:superset:spec.template.spec.containers[0].env[1].value # IFRAME_MODE


### PR DESCRIPTION
Embedding superset inside iframe from a different domain is prevented.

```
Bad Request. The CSRF session token is missing.
```

![image](https://user-images.githubusercontent.com/1540981/94620774-02afe880-0264-11eb-90a7-4cafa227efaa.png)


`SESSION_COOKIE_HTTPONLY = 'False'` can lose restrictions to allow embedding.
See https://github.com/apache/incubator-superset/issues/8382
